### PR TITLE
A fix to allow COARNotificationObject to handle an optional URL property + fix COARNotificationContext are optional depending on the type of notification

### DIFF
--- a/src/COARNotificationActor.php
+++ b/src/COARNotificationActor.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace cottagelabs\coarNotifications;
 
 use JsonSerializable;
@@ -6,7 +7,7 @@ use stdClass;
 
 /**
  *  This identifies the party or process that initiated the activity.
- * 
+ *
  *  See: https://notify.coar-repositories.org/patterns/
  */
 class COARNotificationActor implements JsonSerializable
@@ -15,7 +16,8 @@ class COARNotificationActor implements JsonSerializable
     private string $name;
     private string $type;
 
-    public function __construct(string $id, string $name, string $type) {
+    public function __construct(string $id, string $name, string $type)
+    {
         $this->id = $id;
         $this->name = $name;
         $this->type = $type;

--- a/src/COARNotificationContext.php
+++ b/src/COARNotificationContext.php
@@ -1,33 +1,13 @@
 <?php
+
 namespace cottagelabs\coarNotifications;
 
 /**
  *  This identifies another resource which is relevant to understanding the notification.
- * 
+ *
  *  See: https://notify.coar-repositories.org/patterns/
  */
-class COARNotificationContext extends COARNotificationObject {
-    private COARNotificationURL $url;
+class COARNotificationContext extends COARNotificationObject
+{
 
-    public function __construct(string $id, string $ietfCiteAs, array $type, COARNotificationURL $url) {
-        parent::__construct($id, $ietfCiteAs, $type);
-        $this->url = $url;
-
-    }
-
-    /**
-     * @return COARNotificationURL
-     */
-    public function getUrl(): COARNotificationURL
-    {
-        return $this->url;
-    }
-
-    /**
-     * @param COARNotificationURL $url
-     */
-    public function setUrl(COARNotificationURL $url): void
-    {
-        $this->url = $url;
-    }
 }

--- a/src/COARNotificationManager.php
+++ b/src/COARNotificationManager.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace cottagelabs\coarNotifications;
 
 use cottagelabs\coarNotifications\orm\COARNotification;
@@ -12,6 +13,7 @@ use Doctrine\ORM\ORMException;
 use Doctrine\ORM\ORMSetup;
 use Exception;
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use JsonException;
 use Monolog\Logger;
@@ -27,25 +29,26 @@ use Monolog\Logger;
  *
  * @throws COARNotificationException
  */
-function validate_notification($notification_json): void {
+function validate_notification($notification_json): void
+{
     // Validating that @context has ActivityStreams and Coar notify namespaces.
-    if(!isset($notification_json['@context'])) {
+    if (!isset($notification_json['@context'])) {
         throw new COARNotificationException("The notification must include a '@context' property.");
     }
 
-    if(!count(preg_grep("#^http[s]?://www.w3.org/ns/activitystreams$#", $notification_json['@context']))) {
+    if (!count(preg_grep("#^http[s]?://www.w3.org/ns/activitystreams$#", $notification_json['@context']))) {
         throw new COARNotificationException("The '@context' property must include Activity Streams 2.0 (https://www.w3.org/ns/activitystreams).");
     }
 
-    if(!count(preg_grep("#^http[s]?://purl.org/coar/notify$#", $notification_json['@context']))) {
+    if (!count(preg_grep("#^http[s]?://purl.org/coar/notify$#", $notification_json['@context']))) {
         throw new COARNotificationException("The '@context' property must include Notify (https://purl.org/coar/notify).");
     }
 
     // Validating that id must not be empty
     $mandatory_properties = ['id'];
 
-    foreach($mandatory_properties as $mandatory_property) {
-        if($notification_json[$mandatory_property] === '') {
+    foreach ($mandatory_properties as $mandatory_property) {
+        if ($notification_json[$mandatory_property] === '') {
             throw new COARNotificationException("$mandatory_property is empty.");
         }
 
@@ -61,41 +64,33 @@ function validate_notification($notification_json): void {
  */
 class COARNotificationManager
 {
-    private EntityManager $entityManager;
     public Logger $logger;
     public string $id;
     public string $inbox_url;
     public int $timeout;
     public array $accepted_formats;
     public string $user_agent;
+    private EntityManager $entityManager;
     private bool $connected = false;
 
 
-    public function __construct($conn, Logger $logger=null, string $id=null, string $inbox_url=null,
-                                //$accepted_formats=array('application/ld+json'),
-                                $timeout=5, $user_agent='PHP COAR Notification Manager')
+    public function __construct($conn, Logger $logger = null, string $id = null, string $inbox_url = null,
+        //$accepted_formats=array('application/ld+json'),
+                                $timeout = 5, $user_agent = 'PHP COAR Notification Manager')
     {
-        if(!(is_array($conn) || $conn instanceof Connection))
+        if (!(is_array($conn) || $conn instanceof Connection))
             throw new COARNotificationNoDatabaseException('Either a database connection or' .
                 'a database configuration is required.');
 
-        if(isset($logger))
+        if (isset($logger))
             $this->logger = $logger;
 
         $this->id = $id ?? $_SERVER['SERVER_NAME'];
 
-        if(isset($inbox_url))   {
+        if (isset($inbox_url)) {
             $this->inbox_url = $inbox_url;
-        }
-        else    {
-            if(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off')  {
-                $this->inbox_url = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'];
-            }
-            else {
-                $this->inbox_url = 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'];
-
-            }            
-            
+        } else {
+            $this->inbox_url = $this->buildInboxUrl();
         }
 
         //if(!is_array($accepted_formats))
@@ -109,11 +104,11 @@ class COARNotificationManager
 
         // Deprecated annotation metadata driver needs to be used because the attribute metadata driver requires
         // PHP 8 <
-        $config = ORMSetup::createAnnotationMetadataConfiguration(array(__DIR__."/src/orm"),
+        $config = ORMSetup::createAnnotationMetadataConfiguration(array(__DIR__ . "/src/orm"),
             false, null, null, false);
-        
-        if(is_array($conn))
-            $conn = DriverManager::getConnection($conn, $config);            
+
+        if (is_array($conn))
+            $conn = DriverManager::getConnection($conn, $config);
 
         $this->entityManager = new EntityManager($conn, $config);
 
@@ -121,13 +116,13 @@ class COARNotificationManager
         try {
             $this->entityManager->getConnection()->connect();
 
-            if(isset($this->logger))
+            if (isset($this->logger))
                 $this->logger->debug("Database connection verified.");
             $this->connected = true;
         } catch (Exception $exception) {
             // Printing this exception if logger is not available as this is a fatal
             // initialisation error
-            if(isset($this->logger))
+            if (isset($this->logger))
                 $this->logger->error("Couldn't establish a database connection: " . $exception);
             else
                 print("Couldn't establish a database connection: " . $exception);
@@ -137,59 +132,26 @@ class COARNotificationManager
     }
 
     /**
-     * Gets all COARNotifications sorted by timestamp descending.
-     * 
-     * Note that this uses Doctrine Query Language, DQL see: 
-     * https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/dql-doctrine-query-language.html
-     * 
-     * Doctrine supports pagination, see:
-     * https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/tutorials/pagination.html
-     * 
-     * @param string $direction, 'in', 'out', or default is all
-     * @param string $select columns to select, default is all
-     * @return array results of query as an array
+     * Builds the inbox URL based on the current server configuration.
+     *
+     * @return string The inbox URL of the current server.
      */
-    
-    public function getNotifications(string $direction=NULL, string $select='c'): array    {
-        $queryBuilder = $this->entityManager->createQueryBuilder();
+    private function buildInboxUrl(): string
+    {
+        $protocol = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
 
-        $query = $queryBuilder
-            ->select($select)
-            ->from('cottagelabs\coarNotifications\orm\COARNotification', 'c');
-        
-        if($direction == 'in')  {
-            $query->where('c NOT INSTANCE OF cottagelabs\coarNotifications\orm\OutboundCOARNotification');
-        }
-        else if($direction == 'out')    {
-            $query->where('c INSTANCE OF cottagelabs\coarNotifications\orm\OutboundCOARNotification');
-        }
-        
-        $query->orderBy('c.timestamp', 'DESC')
-            ->setMaxResults(1000);
-    
-        return $queryBuilder->getQuery()->getResult();
-    }
-
-    /**
-     * A wrapper around the preceding method getNotifications that only passes a string
-     * argument to it asking for the 'id' column only.
-     * 
-     * The results are ordered by timestamp descending.
-     * 
-     * @return array an array of UUIDs of notifications
-     */
-    public function getReceivedNotificationIds(): array {
-        return array_column($this->getNotifications('in', 'c.id'), 'id');
+        return $protocol . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'];
     }
 
     /**
      * Sets headers to disclose RDF content types accepted by the server.
-     * 
+     *
      * Should be called in response to a options request.
-     * 
+     *
      * See: https://www.w3.org/TR/2017/REC-ldn-20170502/#sender
      */
-    public function setOptionsResponseHeaders(): void {
+    public function setOptionsResponseHeaders(): void
+    {
         header("Allow: " . implode(', ', ['POST', 'OPTIONS']));
         header("Accept-Post: " . implode(', ', $this->accepted_formats));
 
@@ -198,33 +160,34 @@ class COARNotificationManager
     /**
      * Handles incoming post requests, validates the payload and persists the notification
      * in a database.
-     * 
+     *
      * Accordingly sets one of the following response codes:
      * *  400 if JSON is malformed
      * *  422 if notification is not valid or an error occurs when persisting the notification
      * *  201 if notification is successfully received and persisted
      * *  415 if an unsupported media type is used
      */
-    public function getPostResponse(): void {
+    public function getPostResponse(): void
+    {
         // See https://www.w3.org/TR/2017/REC-ldn-2COARTarget0170502/#sender
         if (str_starts_with($_SERVER["CONTENT_TYPE"], 'application/ld+json')) {
             // Could be followed by a 'profile' but that's not actioned on
             // https://datatracker.ietf.org/doc/html/rfc6906
 
-            if(isset($this->logger))
+            if (isset($this->logger))
                 $this->logger->debug('Received a ld+json POST request.');
 
-            if(!$this->connected)
+            if (!$this->connected)
                 throw new COARNotificationNoDatabaseException();
 
-            
+
             // Validating JSON
             try {
                 $notification_json = json_decode(
                     file_get_contents('php://input'), true, 512,
                     JSON_THROW_ON_ERROR);
             } catch (JsonException $exception) {
-                if(isset($this->logger)) {
+                if (isset($this->logger)) {
                     $this->logger->error("Syntax error: Badly formed JSON in payload.");
                     $this->logger->debug($exception->getTraceAsString());
                 }
@@ -235,7 +198,7 @@ class COARNotificationManager
             try {
                 validate_notification($notification_json);
             } catch (COARNotificationException $exception) {
-                if(isset($this->logger)) {
+                if (isset($this->logger)) {
                     $this->logger->error("Invalid notification: " . $exception->getMessage());
                     $this->logger->debug($exception->getTraceAsString());
                     $this->logger->debug((print_r($notification_json, true)));
@@ -251,12 +214,12 @@ class COARNotificationManager
                 $notification->setFromId($notification_json['origin']['id'] ?? '');
                 $notification->setToId($notification_json['target']['id'] ?? '');
 
-                if($notification_json['type'])
+                if ($notification_json['type'])
                     $notification->setType($notification_json['type']);
 
                 $notification->setOriginal($notification_json);
                 $notification->setStatus(201);
-            } catch (COARNotificationException | Exception $exception) {
+            } catch (COARNotificationException|Exception $exception) {
                 $this->log_error($exception);
                 http_response_code(422);
                 return;
@@ -269,22 +232,80 @@ class COARNotificationManager
             http_response_code(201);
 
         } else {
-            if(isset($this->logger))
+            if (isset($this->logger))
                 $this->logger->debug("415 Unsupported Media Type: received a POST but content type '"
                     . $_SERVER["CONTENT_TYPE"] . "' not an accepted format.");
             http_response_code(415);
         }
-        
+
+    }
+
+    /**
+     * Utility method to log errors
+     *
+     * @param Exception|null $exception
+     * @param bool $trace
+     */
+    private function log_error(?Exception $exception, bool $trace = true): void
+    {
+        if (isset($this->logger)) {
+            $this->logger->error($exception->getMessage());
+
+            if ($trace) {
+                $this->logger->debug($exception->getTraceAsString());
+            }
+        }
+    }
+
+    /**
+     * This method saves both incoming and outgoing COAR Notifications to the database using Doctrine's entity manager.
+     *
+     * @param COARNotification $notification
+     */
+    private function persistNotification(COARNotification $notification): void
+    {
+        try {
+            $this->entityManager->persist($notification);
+            $this->entityManager->flush();
+
+            if (isset($this->logger)) {
+                $msg = 'Wrote ';
+
+                if (is_null($notification->getStatus()) ||
+                    ($notification->getStatus() < 200 || $notification->getStatus() > 299)) {
+                    $msg .= "failed ";
+
+                    if (!is_null($notification->getStatus()))
+                        $msg .= "(" . $notification->getStatus() . ") ";
+                }
+
+                if ($notification instanceof OutboundCOARNotification)
+                    $msg .= "outbound";
+                else
+                    $msg .= "inbound";
+
+                $this->logger->info(sprintf("%s notification (ID: %s) to database.", $msg, $notification->getId()));
+            }
+        } catch (Exception $exception) {
+            $this->log_error($exception);
+
+            // If an inbound notification can't be written to database
+            // then we issue a 422
+            if (get_class($notification) != "OutboundCOARNotification")
+                http_response_code(422);
+
+        }
     }
 
     /**
      * Handles incoming get requests to the inbox url.
-     * 
+     *
      * See: https://www.w3.org/TR/2017/REC-ldn-20170502/#receiving-inbox-contents
-     *  
+     *
      * @return string JSON object with an array of notifications
      */
-    public function getGetResponse(): string {
+    public function getGetResponse(): string
+    {
         header('Content-Type: application/ld+json; charset=utf-8');
         header('Accept: ' . implode(', ', $this->accepted_formats));
 
@@ -297,61 +318,174 @@ class COARNotificationManager
     }
 
     /**
-     * Wrapper to create and return an outbound COARNotification
-     *  
-     * @param COARNotificationActor $actor 
-     * @param COARNotificationObject $obj 
-     * @param COARNotificationContext $ctx
-     * @param COARNotificationTarget $target
-     * 
-     * @throws Exception
-     * @return OutBoundCOARNotification
+     * A wrapper around the preceding method getNotifications that only passes a string
+     * argument to it asking for the 'id' column only.
+     *
+     * The results are ordered by timestamp descending.
+     *
+     * @return array an array of UUIDs of notifications
      */
-    public function createOutboundNotification($actor, $obj, $ctx, $target): OutboundCOARNotification
+    public function getReceivedNotificationIds(): array
     {
-        if(isset($logger))
-            return new OutboundCOARNotification($this->logger, $this->id, $this->inbox_url, $actor, $obj, $ctx, $target);
-        
-        return new OutboundCOARNotification(null, $this->id, $this->inbox_url, $actor, $obj, $ctx, $target);
-    
+        return array_column($this->getNotifications('in', 'c.id'), 'id');
     }
 
     /**
-     * Utility function to process outbound notifications after a pattern has been applied.
+     * Gets all COARNotifications sorted by timestamp descending.
+     *
+     * Note that this uses Doctrine Query Language, DQL see:
+     * https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/dql-doctrine-query-language.html
+     *
+     * Doctrine supports pagination, see:
+     * https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/tutorials/pagination.html
+     *
+     * @param string|null $direction , 'in', 'out', or default is all
+     * @param string $select columns to select, default is all
+     * @return array results of query as an array
      */
-    private function doPattern(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void   {
-        if(!empty($inReplyToId))
-            $outboundCOARNotification->setInReplyToId($inReplyToId);
-        
-        $this->send($outboundCOARNotification);
-        $this->persistNotification($outboundCOARNotification);
+
+    public function getNotifications(string $direction = NULL, string $select = 'c'): array
+    {
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+
+        $query = $queryBuilder
+            ->select($select)
+            ->from('cottagelabs\coarNotifications\orm\COARNotification', 'c');
+
+        if ($direction == 'in') {
+            $query->where('c NOT INSTANCE OF cottagelabs\coarNotifications\orm\OutboundCOARNotification');
+        } else if ($direction == 'out') {
+            $query->where('c INSTANCE OF cottagelabs\coarNotifications\orm\OutboundCOARNotification');
+        }
+
+        $query->orderBy('c.timestamp', 'DESC')
+            ->setMaxResults(1000);
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+
+    /**
+     * Wrapper to create and return an outbound COARNotification
+     *
+     * @param COARNotificationActor $actor
+     * @param COARNotificationObject $obj
+     * @param COARNotificationContext|null $ctx
+     * @param COARNotificationTarget $target
+     *
+     * @return OutBoundCOARNotification
+     * @throws Exception
+     */
+    public function createOutboundNotification(COARNotificationActor $actor, COARNotificationObject $obj, COARNotificationContext $ctx = null, COARNotificationTarget $target): OutboundCOARNotification
+    {
+        $logger = $this->logger ?? null;
+        return new OutboundCOARNotification($logger, $this->id, $this->inbox_url, $actor, $obj, $ctx, $target);
     }
 
     /**
      * This pattern is used to acknowledge and accept a request (offer).
-     * 
+     *
      * https://notify.coar-repositories.org/patterns/acknowledge-acceptance/
      * @param OutboundCOARNotification $outboundCOARNotification
      * @param null $inReplyToId
      * @throws COARNotificationException
      * @throws COARNotificationNoDatabaseException
      */
-    public function acknowledgeAndAccept(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void {
+    public function acknowledgeAndAccept(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void
+    {
         $outboundCOARNotification->setType(["Accept"]);
 
         $this->doPattern($outboundCOARNotification, $inReplyToId);
     }
 
     /**
+     * Utility function to process outbound notifications after a pattern has been applied.
+     */
+    private function doPattern(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void
+    {
+        if (!empty($inReplyToId))
+            $outboundCOARNotification->setInReplyToId($inReplyToId);
+
+        $this->send($outboundCOARNotification);
+        $this->persistNotification($outboundCOARNotification);
+    }
+
+    /**
+     * This method uses Guzzle to send an outbound COAR Notification to a URL.
+     *
+     * 400-500 HTTP errors will raise and error, can be disabled by ['http_errors' => false] in Guzzle client initiation
+     *
+     * @param OutboundCOARNotification $outboundCOARNotification
+     * @throws GuzzleException
+     */
+    private function send(OutboundCOARNotification $outboundCOARNotification): void
+    {
+        $this->log_info(sprintf("Sending notification (ID: %s) to %s", $outboundCOARNotification->getId(), $outboundCOARNotification->getTargetURL()));
+
+        $client = new \GuzzleHttp\Client();
+
+        try {
+            $res = $client->request('POST', $outboundCOARNotification->getTargetURL(), [
+                'timeout' => $this->timeout,
+                'headers' => ['Content-Type' => 'application/ld+json', 'User-Agent' => $this->user_agent],
+                'body' => $outboundCOARNotification->getJSON(),
+            ]);
+
+            $outboundCOARNotification->setStatus($res->getStatusCode());
+        } catch (ConnectException|RequestException $exception) {
+            // Guzzle will use cURL by default, we can therefore expect a ContextHandler with
+            // cURL error codes
+            $ctx = $exception->getHandlerContext();
+
+            if (in_array('errno', $ctx)) {
+                $error_no = $ctx['errno'];
+                $outboundCOARNotification->setStatus($error_no);
+
+                $msg = "Outbound notification (ID: " . $outboundCOARNotification->getId() . ") could not be sent.";
+                // Timed out?
+                if ($error_no === 7)
+                    $msg .= " Couldn't connect to " . $outboundCOARNotification->getTargetURL();
+                else if ($error_no === 28)
+                    $msg .= " Timed out.";
+                else
+                    $msg .= " cURL error no: " . $error_no;
+
+                if (isset($this->logger))
+                    $this->logger->error($msg);
+
+            }
+
+            $this->log_error($exception);
+
+        } catch (Exception $exception) {
+            $this->log_error($exception);
+
+        }
+
+    }
+
+    /**
+     * Utility method to log info
+     *
+     * @param string $msg
+     */
+    private function log_info(string $msg): void
+    {
+        if (isset($this->logger)) {
+            $this->logger->info($msg);
+        }
+    }
+
+    /**
      * This pattern is used to acknowledge and reject a request (offer).
-     * 
+     *
      * https://notify.coar-repositories.org/patterns/acknowledge-rejection/
      * @param OutboundCOARNotification $outboundCOARNotification
      * @param null $inReplyToId
      * @throws COARNotificationException
      * @throws COARNotificationNoDatabaseException
      */
-    public function acknowledgeAndReject(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void {
+    public function acknowledgeAndReject(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void
+    {
         $outboundCOARNotification->setType(["Reject"]);
 
         $this->doPattern($outboundCOARNotification, $inReplyToId);
@@ -366,7 +500,8 @@ class COARNotificationManager
      * @throws COARNotificationException
      * @throws COARNotificationNoDatabaseException
      */
-    public function announceEndorsement(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void {
+    public function announceEndorsement(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void
+    {
         $outboundCOARNotification->setType(["Announce", "coar-notify:EndorsementAction"]);
 
         $this->doPattern($outboundCOARNotification, $inReplyToId);
@@ -374,14 +509,15 @@ class COARNotificationManager
 
     /**
      * This pattern is used to announce a resource has been ingested.
-     * 
+     *
      * https://notify.coar-repositories.org/patterns/announce-ingest/
      * @param OutboundCOARNotification $outboundCOARNotification
      * @param null $inReplyToId
      * @throws COARNotificationException
      * @throws COARNotificationNoDatabaseException
      */
-    public function announceIngest(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void {
+    public function announceIngest(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void
+    {
         $outboundCOARNotification->setType(["Announce", "coar-notify:IngestAction"]);
 
         $this->doPattern($outboundCOARNotification, $inReplyToId);
@@ -389,14 +525,15 @@ class COARNotificationManager
 
     /**
      * This pattern is used to announce a relationship between two resources.
-     * 
+     *
      * https://notify.coar-repositories.org/patterns/announce-relationship/
      * @param OutboundCOARNotification $outboundCOARNotification
      * @param null $inReplyToId
      * @throws COARNotificationException
      * @throws COARNotificationNoDatabaseException
      */
-    public function announceRelationship(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void {
+    public function announceRelationship(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void
+    {
         $outboundCOARNotification->setType(["Announce", "coar-notify:RelationshipAction"]);
 
         $this->doPattern($outboundCOARNotification, $inReplyToId);
@@ -411,7 +548,8 @@ class COARNotificationManager
      * @throws COARNotificationException
      * @throws COARNotificationNoDatabaseException
      */
-    public function announceReview(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void {
+    public function announceReview(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void
+    {
         $outboundCOARNotification->setType(["Announce", "coar-notify:ReviewAction"]);
 
         $this->doPattern($outboundCOARNotification, $inReplyToId);
@@ -421,9 +559,11 @@ class COARNotificationManager
      * This pattern is used to request endorsement of a resource owned by the origin system.
      * https://notify.coar-repositories.org/patterns/request-endorsement/
      * @param OutboundCOARNotification $outboundCOARNotification
+     * @param null $inReplyToId
      * @throws COARNotificationException
      */
-    public function requestEndorsement(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void {
+    public function requestEndorsement(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void
+    {
         $outboundCOARNotification->setType(["Offer", "coar-notify:EndorsementAction"]);
 
         $this->doPattern($outboundCOARNotification, $inReplyToId);
@@ -433,9 +573,11 @@ class COARNotificationManager
      * This pattern is used to request that the target system ingest a resource.
      * https://notify.coar-repositories.org/patterns/request-ingest/
      * @param OutboundCOARNotification $outboundCOARNotification
+     * @param null $inReplyToId
      * @throws COARNotificationException
      */
-    public function requestIngest(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void {
+    public function requestIngest(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void
+    {
         $outboundCOARNotification->setType(["Offer", "coar-notify:IngestAction"]);
 
         $this->doPattern($outboundCOARNotification, $inReplyToId);
@@ -446,9 +588,11 @@ class COARNotificationManager
      * Implements step 3 of scenario 2
      * https://notify.coar-repositories.org/scenarios/2/2/
      * @param OutboundCOARNotification $outboundCOARNotification
+     * @param null $inReplyToId
      * @throws COARNotificationException
      */
-    public function requestReview(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void {
+    public function requestReview(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void
+    {
         $outboundCOARNotification->setType(["Offer", "coar-notify:ReviewAction"]);
 
         $this->doPattern($outboundCOARNotification, $inReplyToId);
@@ -458,124 +602,21 @@ class COARNotificationManager
      * This pattern is used to retract (undo) an offer previously made.
      * https://notify.coar-repositories.org/patterns/undo-offer/
      * @param OutboundCOARNotification $outboundCOARNotification
+     * @param null $inReplyToId
      * @throws COARNotificationException
      */
-    public function retractOffer(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void {    
+    public function retractOffer(OutboundCOARNotification $outboundCOARNotification, $inReplyToId = null): void
+    {
         $outboundCOARNotification->setType(["Undo"]);
 
         $this->doPattern($outboundCOARNotification, $inReplyToId);
     }
 
     /**
-     * This method uses Guzzle to send an outbound COAR Notification to a URL.
-     * 
-     * 400-500 HTTP errors will raise and error, can be disabled by ['http_errors' => false] in Guzzle client initiation
-     * 
-     * @param OutboundCOARNotification $outboundCOARNotification
-     */
-    private function send(OutboundCOARNotification $outboundCOARNotification): void {
-        $this->log_info(sprintf("Sending notification (ID: %s) to %s", $outboundCOARNotification->getId(), $outboundCOARNotification->getTargetURL()));
-
-        $client = new \GuzzleHttp\Client();
-
-        try {
-            $res = $client->request('POST', $outboundCOARNotification->getTargetURL(), [
-                'timeout' => $this->timeout,
-                'headers' => ['Content-Type' => 'application/ld+json', 'User-Agent' => $this->user_agent],
-                'body' => $outboundCOARNotification->getJSON(),
-            ]);
-
-            $outboundCOARNotification->setStatus($res->getStatusCode());
-        }
-        catch (ConnectException | RequestException $exception) {
-            // Guzzle will use cURL by default, we can therefore expect a ContextHandler with
-            // cURL error codes
-            $ctx = $exception->getHandlerContext();
-
-            if(in_array('errno', $ctx)) {
-                $error_no = $ctx['errno'];
-                $outboundCOARNotification->setStatus($error_no);
-
-                $msg = "Outbound notification (ID: " . $outboundCOARNotification->getId() . ") could not be sent.";
-                // Timed out?
-                if($error_no === 7)
-                    $msg .= " Couldn't connect to " . $outboundCOARNotification->getTargetURL();
-                else if($error_no === 28)
-                    $msg .= " Timed out.";
-                else
-                    $msg .= " cURL error no: " . $error_no;
-
-                if(isset($this->logger))
-                    $this->logger->error($msg);
-
-            }
-
-            $this->log_error($exception);
-
-        }
-        catch (Exception $exception) {
-            $this->log_error($exception);
-
-        }
-
-    }
-
-    /**
-     * This method saves both incoming and outgoing COAR Notifications to the database using Doctrine's entity manager.
-     * 
-     * @param COARNotification $notification
-     */
-    private function persistNotification(COARNotification $notification): void {
-        try {
-            $this->entityManager->persist($notification);
-            $this->entityManager->flush();
-
-            if(isset($this->logger)) {
-                $msg = 'Wrote ';
-
-                if(is_null($notification->getStatus()) ||
-                    ($notification->getStatus() < 200 || $notification->getStatus() > 299)) {
-                    $msg .= "failed ";
-
-                    if(!is_null($notification->getStatus()))
-                        $msg .= "(" . $notification->getStatus() . ") ";
-                }
-
-                if ($notification instanceof OutboundCOARNotification)
-                    $msg .= "outbound";
-                else
-                    $msg .= "inbound";
-
-                $this->logger->info(sprintf("%s notification (ID: %s) to database.", $msg, $notification->getId()));
-            }
-        }
-        catch (Exception $exception) {
-            $this->log_error($exception);
-
-            // If an inbound notification can't be written to database
-            // then we issue a 422
-            if(get_class($notification) != "OutboundCOARNotification")
-                http_response_code(422);
-
-        }
-    }
-
-    /**
-     * Gets and returns a COAR Notification from the database by id.
-     * 
-     * @param string $notificationId
-     * @return COARNotification
-     */
-    public function getNotificationById(string $notificationId): ?COARNotification
-    {
-        return $this->entityManager->getReference(COARNotification::class, $notificationId);
-        
-    }
-
-    /**
      * Removes a COAR Notification by id.
-     * 
-     *  @param string $notificationId
+     *
+     * @param string $notificationId
+     * @throws \Doctrine\ORM\Exception\ORMException
      */
     public function removeNotificationById(string $notificationId): void
     {
@@ -586,41 +627,27 @@ class COARNotificationManager
             $this->entityManager->remove($notificationToRemove);
             $this->entityManager->flush();
             $this->log_info(sprintf("Removing notification (ID: %s) from database.", $notificationId));
- 
+
         } catch (Exception $exception) {
             $this->log_error($exception);
         }
     }
 
-    public function __toString(): string {
+    /**
+     * Gets and returns a COAR Notification from the database by id.
+     *
+     * @param string $notificationId
+     * @return COARNotification
+     * @throws \Doctrine\ORM\Exception\ORMException
+     */
+    public function getNotificationById(string $notificationId): ?COARNotification
+    {
+        return $this->entityManager->getReference(COARNotification::class, $notificationId);
+
+    }
+
+    public function __toString(): string
+    {
         return static::class . $this->id;
     }
-
-    /**
-     * Utility method to log errors
-     * 
-     * @param Exception $exception
-     * @param bool $trace
-     */
-    private function log_error(?Exception $exception, bool $trace=true): void {
-        if (isset($this->logger)) {
-            $this->logger->error($exception->getMessage());
-
-            if($trace)  {
-                $this->logger->debug($exception->getTraceAsString());
-            }
-        }
-    }
-
-    /**
-     * Utility method to log info
-     * 
-     * @param string $msg
-     */
-    private function log_info(string $msg): void {
-        if (isset($this->logger)) {
-            $this->logger->info($msg);
-        }
-    }
-
 }

--- a/src/COARNotificationObject.php
+++ b/src/COARNotificationObject.php
@@ -1,20 +1,25 @@
 <?php
+
 namespace cottagelabs\coarNotifications;
 
 /**
  *  This should be the focus of the activity. Other object properties may appear in notifications, as properties of other properties.
- * 
+ *
  *  See: https://notify.coar-repositories.org/patterns/
  */
-class COARNotificationObject {
+class COARNotificationObject
+{
     private string $id;
     private string $ietfCiteAs;
     private array $type;
+    private ?COARNotificationURL $url;
 
-    public function __construct(string $id, string $ietfCiteAs, array $type) {
+    public function __construct(string $id, string $ietfCiteAs, array $type, COARNotificationURL $url = null)
+    {
         $this->id = $id;
         $this->ietfCiteAs = $ietfCiteAs;
         $this->type = $type;
+        $this->url = $url;
 
     }
 
@@ -64,5 +69,21 @@ class COARNotificationObject {
     public function setType(array $type): void
     {
         $this->type = $type;
+    }
+
+    /**
+     * @return COARNotificationURL|null
+     */
+    public function getUrl(): ?COARNotificationURL
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param COARNotificationURL|null $url
+     */
+    public function setUrl(COARNotificationURL $url = null): void
+    {
+        $this->url = $url;
     }
 }

--- a/src/COARNotificationTarget.php
+++ b/src/COARNotificationTarget.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace cottagelabs\coarNotifications;
 
 use JsonSerializable;
@@ -6,15 +7,17 @@ use stdClass;
 
 /**
  *  The intended destination of the activity, typically the service which consumes the notification.
- * 
+ *
  *  See: https://notify.coar-repositories.org/patterns/
  */
-class COARNotificationTarget implements JsonSerializable {
+class COARNotificationTarget implements JsonSerializable
+{
     private string $id;
     private string $inbox;
     private string $type;
 
-    public function __construct(string $id, string $inbox, string $type = "Service") {
+    public function __construct(string $id, string $inbox, string $type = "Service")
+    {
         $this->id = $id;
         $this->inbox = $inbox;
         $this->type = $type;

--- a/src/COARNotificationURL.php
+++ b/src/COARNotificationURL.php
@@ -1,15 +1,18 @@
 <?php
+
 namespace cottagelabs\coarNotifications;
 
 /**
  * A simple class to describe URLS for COAR Notifications.
  */
-class COARNotificationURL {
+class COARNotificationURL
+{
     private string $id;
     private string $mediaType;
     private array $type;
 
-    public function __construct(string $id, string $mediaType, array $type) {
+    public function __construct(string $id, string $mediaType, array $type)
+    {
         $this->id = $id;
         $this->mediaType = $mediaType;
         $this->type = $type;

--- a/src/orm/COARNotification.php
+++ b/src/orm/COARNotification.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace cottagelabs\coarNotifications\orm;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -23,7 +24,8 @@ const ACTIVITIES = array('accept', 'add', 'announce', 'arrive', 'block', 'create
  * @ORM\DiscriminatorMap({"INBOUND" = "COARNotification", "OUTBOUND" = "OutboundCOARNotification"})
  * @ORM\Table(name="notifications")
  */
-class COARNotification {
+class COARNotification
+{
 
     private Logger $logger;
 
@@ -73,28 +75,20 @@ class COARNotification {
      * @ORM\Column(type="datetime", nullable=false)
      * @ORM\Version
      */
-     private $timestamp;
+    private $timestamp;
 
     /**
      * @ORM\Column(type="json")
      */
-     private string $original;
+    private string $original;
 
     /**
      */
-    public function __construct(Logger $logger=null)
+    public function __construct(Logger $logger = null)
     {
-        if(isset($logger))
+        if (isset($logger))
             $this->logger = $logger;
 
-    }
-
-    /**
-     * @param mixed $original
-     */
-    public function setOriginal($original): void
-    {
-        $this->original = json_encode($original);
     }
 
     /**
@@ -106,28 +100,11 @@ class COARNotification {
     }
 
     /**
-     * Called with parameter when notification is inbound.
-     * Called without parameter when notification is outbound.
-     * @param string|null $id
-     * @throws Exception
+     * @param mixed $original
      */
-    public function setId(string $id = null): void
+    public function setOriginal($original): void
     {
-        if(empty($this->id) && empty($id)) {
-            $id = "urn:uuid:" . Uuid::uuid4()->serialize();
-        }
-
-        $this->validateId($id);
-
-        $this->id = $id;
-    }
-
-    /**
-     * @param mixed $status
-     */
-    public function setStatus($status): void
-    {
-        $this->status = $status;
+        $this->original = json_encode($original);
     }
 
     /**
@@ -139,11 +116,27 @@ class COARNotification {
     }
 
     /**
+     * @param mixed $status
+     */
+    public function setStatus($status): void
+    {
+        $this->status = $status;
+    }
+
+    /**
      * @param mixed $inReplyToId
      */
     public function setInReplyToId(string $inReplyToId): void
     {
         $this->inReplyToId = $inReplyToId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFromId(): string
+    {
+        return $this->fromId;
     }
 
     /**
@@ -155,74 +148,19 @@ class COARNotification {
     }
 
     /**
-     * @param string $toId
-     */
-    public function setToId(string $toId): void
-    {
-        $this->toId = $toId;
-    }
-    /**
-     * @return string
-     */
-    public function getFromId(): string
-    {
-        return $this->fromId;
-    }
-
-    /**
      * @return string
      */
     public function getToId(): string
     {
         return $this->toId;
     }
-    /**
-     * Validates $id argument passed to Notification constructor.
-     * It's recommended to be URN:UUID, an HTTP URI may be used.
-     * It is checked for being either UUID4 or a valid URL.
-     * @param $id
-     * @throws COARNotificationException
-     */
-    private function validateId($id):void {
-        // Only condition that can be considered invalid $id
-        if($id === "") {
-            if(isset($this->logger))
-                $this->logger->error('UId can not be null.');
-            throw new COARNotificationException('UId can not be null.');
-        }
-
-        $pattern = '/^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/';
-
-        if (!filter_var($id, FILTER_VALIDATE_URL) && (preg_match($pattern, $id) === 0)) {
-            if(isset($this->logger))
-                $this->logger->warning("(UId: '$id') Uid is neither a valid URL nor an UUID.");
-        }
-
-
-    }
 
     /**
-     * A notification can be of more than one type and at least one must be an Activity Stream 2.0 Activity Type .
-     * @throws COARNotificationException
+     * @param string $toId
      */
-    protected function validateType(array $type):void {
-        if(count(array_intersect(array_map('strtolower', $type), ACTIVITIES)) > 0) {
-            if (isset($this->logger))
-                $this->logger->warning("(UId: '" . $this->getId() . "')"
-                    . "Does not have an Activity Stream 2.0 Activity Type.");
-
-        }
-    }
-
-    /**
-     * @return string
-     */
-    public function getId(): string
+    public function setToId(string $toId): void
     {
-        if(empty($this->id))
-            return "";
-
-        return $this->id;
+        $this->toId = $toId;
     }
 
     /**
@@ -245,6 +183,74 @@ class COARNotification {
     {
         $this->validateType($type);
         $this->type = json_encode($type);
+    }
+
+    /**
+     * A notification can be of more than one type and at least one must be an Activity Stream 2.0 Activity Type .
+     * @throws COARNotificationException
+     */
+    protected function validateType(array $type): void
+    {
+        if (count(array_intersect(array_map('strtolower', $type), ACTIVITIES)) > 0) {
+            if (isset($this->logger))
+                $this->logger->warning("(UId: '" . $this->getId() . "')"
+                    . "Does not have an Activity Stream 2.0 Activity Type.");
+
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        if (empty($this->id))
+            return "";
+
+        return $this->id;
+    }
+
+    /**
+     * Called with parameter when notification is inbound.
+     * Called without parameter when notification is outbound.
+     * @param string|null $id
+     * @throws Exception
+     */
+    public function setId(string $id = null): void
+    {
+        if (empty($this->id) && empty($id)) {
+            $id = "urn:uuid:" . Uuid::uuid4()->serialize();
+        }
+
+        $this->validateId($id);
+
+        $this->id = $id;
+    }
+
+    /**
+     * Validates $id argument passed to Notification constructor.
+     * It's recommended to be URN:UUID, an HTTP URI may be used.
+     * It is checked for being either UUID4 or a valid URL.
+     * @param $id
+     * @throws COARNotificationException
+     */
+    private function validateId($id): void
+    {
+        // Only condition that can be considered invalid $id
+        if ($id === "") {
+            if (isset($this->logger))
+                $this->logger->error('UId can not be null.');
+            throw new COARNotificationException('UId can not be null.');
+        }
+
+        $pattern = '/^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/';
+
+        if (!filter_var($id, FILTER_VALIDATE_URL) && (preg_match($pattern, $id) === 0)) {
+            if (isset($this->logger))
+                $this->logger->warning("(UId: '$id') Uid is neither a valid URL nor an UUID.");
+        }
+
+
     }
 
     public function __toString(): string

--- a/src/orm/COARNotificationException.php
+++ b/src/orm/COARNotificationException.php
@@ -1,6 +1,9 @@
 <?php
+
 namespace cottagelabs\coarNotifications\orm;
 
 use Exception;
 
-class COARNotificationException extends Exception {}
+class COARNotificationException extends Exception
+{
+}

--- a/src/orm/COARNotificationNoDatabaseException.php
+++ b/src/orm/COARNotificationNoDatabaseException.php
@@ -1,11 +1,14 @@
 <?php
+
 namespace cottagelabs\coarNotifications\orm;
 
 use Throwable;
 
-class COARNotificationNoDatabaseException extends COARNotificationException {
+class COARNotificationNoDatabaseException extends COARNotificationException
+{
     // Redefine the exception so message isn't optional
-    public function __construct($message="No database connection.", $code = 0, Throwable $previous = null) {
+    public function __construct($message = "No database connection.", $code = 0, Throwable $previous = null)
+    {
         parent::__construct($message, $code, $previous);
     }
 }

--- a/src/orm/OutboundCOARNotification.php
+++ b/src/orm/OutboundCOARNotification.php
@@ -1,10 +1,12 @@
 <?php
+
 namespace cottagelabs\coarNotifications\orm;
 
 use cottagelabs\coarNotifications\COARNotificationActor;
 use cottagelabs\coarNotifications\COARNotificationContext;
 use cottagelabs\coarNotifications\COARNotificationObject;
 use cottagelabs\coarNotifications\COARNotificationTarget;
+use cottagelabs\coarNotifications\COARNotificationURL;
 use Doctrine\ORM\Mapping as ORM;
 use Exception;
 use Monolog\Logger;
@@ -14,33 +16,27 @@ use stdClass;
  * @ORM\Entity
  * @ORM\Table(name="notifications")
  */
-class OutboundCOARNotification extends COARNotification {
+class OutboundCOARNotification extends COARNotification
+{
 
     protected object $base;
     private Logger $logger;
 
-    /**
-     * @throws Exception
-     */
-    public function __construct(Logger                  $logger=null, string $id, string $inbox_url,
+    public function __construct(Logger                  $logger = null, string $id, string $inbox_url,
                                 COARNotificationActor   $actor, COARNotificationObject $obj,
-                                COARNotificationContext $ctx, COARNotificationTarget $target)
+                                COARNotificationContext $ctx = null, COARNotificationTarget $target)
     {
         parent::__construct($logger);
 
-        if(isset($logger))
+        if (isset($logger)) {
             $this->logger = $logger;
+        }
 
         $this->base = new stdClass();
-        $this->base->{'@context'} = ["https://www.w3.org/ns/activitystreams", "http://purl.org/coar/notify"];
+        $this->base->{'@context'} = ["https://www.w3.org/ns/activitystreams", "https://purl.org/coar/notify"];
 
         // Origin
-        $this->base->origin = new stdClass();
-        $this->base->origin->type = ["Service"];
-        $this->base->origin->id = $id;
-        $this->base->origin->inbox = $inbox_url;
-
-        $this->base->actor = new stdClass();
+        $this->base->origin = $this->createObject(["Service"], $id, $inbox_url);
 
         $this->setId();
         $this->base->id = $this->getId();
@@ -51,24 +47,73 @@ class OutboundCOARNotification extends COARNotification {
         $this->base->actor = $actor;
 
         // Object with a special character property name
-        $this->base->object = new stdClass();
-        $this->base->object->type = $obj->getType();
-        $this->base->object->id = $obj->getId();
-        $this->base->object->{'ietf:cite-as'} = $obj->getIetfCiteAs();
+        $this->base->object = $this->createNotificationObject($obj);
 
-        // Context and child URL object both with special character property name
-        $this->base->context = new stdClass();
-        $this->base->context->id = $ctx->getId();
-        $this->base->context->{'ietf:cite-as'} = $ctx->getIetfCiteAs();
-        $this->base->context->url = new stdClass();
-        $this->base->context->url->id = $ctx->getUrl()->getId();
-        $this->base->context->url->{"mediaType"} = $ctx->getUrl()->getMediaType();
-        $this->base->context->url->type =  $ctx->getUrl()->getType();
+        if ($ctx !== null) {
+            $this->base->context = $this->createNotificationObject($ctx);
+        }
 
         $this->base->target = $target;
 
         $this->setOriginal($this->base);
 
+    }
+
+    /**
+     * Create a new object with the given type, id, and inbox URL.
+     *
+     * @param array $type The type of the object (e.g. ["Service"]).
+     * @param string $id The id of the object.
+     * @param string $inbox_url The inbox URL of the object.
+     * @return stdClass The created object.
+     */
+    private function createObject(array $type, string $id, string $inbox_url): stdClass
+    {
+        $object = new stdClass();
+        $object->type = $type;
+        $object->id = $id;
+        $object->inbox = $inbox_url;
+
+        return $object;
+    }
+
+    /**
+     * Creates a notification object based on the given COARNotificationObject.
+     *
+     * @param COARNotificationObject $obj The COARNotificationObject to create the notification object from.
+     * @return stdClass The created notification object.
+     * @throws Exception If there is an error creating the notification object.
+     */
+    private function createNotificationObject(COARNotificationObject $obj): stdClass
+    {
+        $object = new stdClass();
+        $object->type = $obj->getType();
+        $object->id = $obj->getId();
+        $object->{'ietf:cite-as'} = $obj->getIetfCiteAs();
+
+        if ($obj->getUrl() !== null) {
+            $object->url = $this->createUrlObject($obj->getUrl());
+        }
+
+        return $object;
+    }
+
+
+    /**
+     * Creates a URL object based on a COARNotificationURL instance.
+     *
+     * @param COARNotificationURL $url The COARNotificationURL instance.
+     * @return stdClass The URL object.
+     * @throws Exception If an error occurs during the creation of the URL object.
+     */
+    private function createUrlObject(COARNotificationURL $url): stdClass
+    {
+        $urlObject = new stdClass();
+        $urlObject->id = $url->getId();
+        $urlObject->mediaType = $url->getMediaType();
+        $urlObject->type = $url->getType();
+
+        return $urlObject;
     }
 
     public function setType(array $type): void
@@ -77,11 +122,13 @@ class OutboundCOARNotification extends COARNotification {
         $this->base->type = $type;
     }
 
-    public function getJSON(): string {
+    public function getJSON(): string
+    {
         return json_encode($this->base);
     }
 
-    public function getTargetURL(): string {
+    public function getTargetURL(): string
+    {
         return $this->base->target->getInbox();
     }
 


### PR DESCRIPTION
A proposed fix for issue #3 

This update allows COARNotificationObject to handle an optional URL property.
Now COARNotificationContext extends COARNotificationObject. COARNotificationContext are optional depending on the type of notification.

In the COARNotificationActor.php and COARNotificationContext.php files, changes involve reformatting the constructor methods.

In the COARNotificationManager.php file, changes include:
- Auto-reformatting of several methods to increase readability.
- Addition of type hinting for method parameters.
- Repositioning of class attributes for better organization.
- Addition of docstrings for certain methods to provide explanations of their functions.
- Addition of a 'buildInboxUrl' method to generate the inbox URL based on current server configuration.